### PR TITLE
Feature/26

### DIFF
--- a/src/app/api/[[...route]]/users/index.ts
+++ b/src/app/api/[[...route]]/users/index.ts
@@ -108,7 +108,7 @@ app.post("/:id/follow/:followerId", async (c) => {
       },
     });
 
-    return c.json({ message: "Followed", follow: follow });
+    return c.json({ message: "フォロー完了", follow: follow });
   } catch (error) {
     if (!error) {
       console.error("ユーザーのフォロー処理に失敗しました:", error);

--- a/src/app/api/[[...route]]/users/index.ts
+++ b/src/app/api/[[...route]]/users/index.ts
@@ -15,6 +15,7 @@ const userScheme = z.object({
   isPrivate: z.boolean().optional(),
 });
 
+// ユーザー情報を取得するエンドポイント
 app.get("/:id", async (c) => {
   const id = c.req.param("id");
   try {
@@ -62,6 +63,7 @@ app.get("/:id", async (c) => {
   }
 });
 
+// ユーザー情報を更新するエンドポイント
 app.patch("/:id", zValidator("json", userScheme), async (c) => {
   const id = c.req.param("id");
   const body = c.req.valid("json");


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
`[post] /user/:id/follow/followerId ` ユーザーをフォローするapiを実装

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #26 

## 変更内容
<!-- 変更内容を具体的に記載してください -->
### `src/app/api/[[...route]]/users/index.ts`
- [ ] upsertによるfollow処理を実装
- [ ] user周りの各api実装に対してコメントアウトを記載

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->

### 変更前

### 変更後

## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [x] ローカル環境で動作確認済み
- [ ] 必要なテストを追加/更新済み
- [ ] テストが全て成功することを確認済み
- [x] Lintエラーがないことを確認済み

### postmanでの検証
* cookieを消した状態でログイン条件分岐が問題なく動作する
* followテーブルでまだfollow情報がない時に問題なく追加される
* followテーブルですでにfollow情報があるときに上書きされることなく保持される

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->
* apiリクエストのpath構造はこれでいいかどうか

## その他
<!-- その他、補足事項があれば記載してください -->

### upsertの実装について
createで実装するパターンもあったが，apiの責務として以下の点を考慮してupsertにした
* 複数端末でどちらもフォロー可能なUIでフォロー動作をした場合，片方がサーバーエラーの発生が起こる可能性がある点
* followはあくまでfollowをする状態にすることが目的で，それができていたら処理は成功と言えるのでは？という点

### エラーハンドリングのcatch内でerrorのnull判定を行っている
* なぜかnullになって返ってくるので，nullの時はerrro文を入れず，そのまま「ユーザーのフォロー処理に失敗しました」とだけ返すようにしている