### PR TITLE
Feature/27 

### DIFF
--- a/src/app/api/[[...route]]/users/index.ts
+++ b/src/app/api/[[...route]]/users/index.ts
@@ -118,4 +118,43 @@ app.post("/:id/follow/:followerId", async (c) => {
     return c.json({ error: "ユーザーフォロー処理に失敗しました" }, 500);
   }
 });
+
+// フォロー解除するエンドポイント
+app.delete("/:id/follow/:followerId", async (c) => {
+  const id = c.req.param("id");
+  const followerId = c.req.param("followerId");
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return c.json({ error: "ログインしていないユーザーです" }, 401);
+  }
+
+  try {
+    const follow = await prisma.follow.delete({
+      where: {
+        followerId_followingId: {
+          followingId: id,
+          followerId: followerId,
+        },
+      },
+    });
+
+    return c.json({ message: "フォロー解除完了", follow: follow });
+  } catch (error) {
+    const isFollowing = await prisma.follow.findFirst({
+      where: {
+        followerId: followerId,
+        followingId: id,
+      },
+    });
+    if (!isFollowing) {
+      return c.json({ error: "既にフォローが解除されています" }, 500);
+    }
+    if (!error) {
+      console.error("ユーザーのフォロー解除処理に失敗しました:", error);
+    } else {
+      console.error("ユーザーのフォロー解除処理に失敗しました:");
+    }
+    return c.json({ error: "ユーザーフォロー解除処理に失敗しました" }, 500);
+  }
+});
 export default app;

--- a/src/app/api/[[...route]]/users/index.ts
+++ b/src/app/api/[[...route]]/users/index.ts
@@ -1,3 +1,4 @@
+import { recoverFromNotFound } from "@/app/api/[[...route]]/utils";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { zValidator } from "@hono/zod-validator";
@@ -94,19 +95,6 @@ app.post("/:id/follow/:followerId", async (c) => {
   }
 
   try {
-    // const follow = await prisma.follow.upsert({
-    //   where: {
-    //     followerId_followingId: {
-    //       followingId: id,
-    //       followerId: followerId,
-    //     },
-    //   },
-    //   update: {},
-    //   create: {
-    //     followerId: followerId,
-    //     followingId: id,
-    //   },
-    // });
     const follow = await prisma.follow.create({
       data: {
         followerId: followerId,
@@ -144,26 +132,22 @@ app.delete("/:id/follow/:followerId", async (c) => {
   }
 
   try {
-    const follow = await prisma.follow.delete({
-      where: {
-        followerId_followingId: {
-          followingId: id,
-          followerId: followerId,
+    const follow = await recoverFromNotFound(
+      prisma.follow.delete({
+        where: {
+          followerId_followingId: {
+            followingId: id,
+            followerId: followerId,
+          },
         },
-      },
-    });
+      }),
+    );
+    if (!follow) {
+      return c.json({ error: "フォローしていません" }, 500);
+    }
 
     return c.json({ message: "フォロー解除完了", follow: follow });
   } catch (error) {
-    const isFollowing = await prisma.follow.findFirst({
-      where: {
-        followerId: followerId,
-        followingId: id,
-      },
-    });
-    if (!isFollowing) {
-      return c.json({ error: "既にフォローが解除されています" }, 500);
-    }
     if (!error) {
       console.error("ユーザーのフォロー解除処理に失敗しました:", error);
     } else {

--- a/src/app/api/[[...route]]/users/index.ts
+++ b/src/app/api/[[...route]]/users/index.ts
@@ -95,24 +95,21 @@ app.post("/:id/follow/:followerId", async (c) => {
   }
 
   try {
-    const follow = await prisma.follow.create({
-      data: {
-        followerId: followerId,
-        followingId: id,
-      },
-    });
+    const follow = await recoverFromNotFound(
+      prisma.follow.create({
+        data: {
+          followerId: followerId,
+          followingId: id,
+        },
+      }),
+    );
+
+    if (!follow) {
+      return c.json({ error: "既にフォローしています" }, 500);
+    }
 
     return c.json({ message: "フォロー完了", follow: follow });
   } catch (error) {
-    const isFollowing = await prisma.follow.findFirst({
-      where: {
-        followerId: followerId,
-        followingId: id,
-      },
-    });
-    if (isFollowing) {
-      return c.json({ error: "既にフォローされています" }, 500);
-    }
     if (!error) {
       console.error("ユーザーのフォロー処理に失敗しました:", error);
     } else {

--- a/src/app/api/[[...route]]/users/index.ts
+++ b/src/app/api/[[...route]]/users/index.ts
@@ -19,138 +19,136 @@ const userScheme = z.object({
 });
 
 // ユーザー情報を取得するエンドポイント
-app.get("/:id", async (c) => {
-  const id = c.req.param("id");
-  try {
-    const data = await prisma.user.findUnique({
-      where: {
-        id: id,
-      },
-      include: {
-        goals: {
-          select: {
-            id: true,
-            isPublic: true,
-            text: true,
-          },
-        },
-        UserInterest: {
-          select: {
-            interest: true,
-          },
-        },
-      },
-    });
-
-    const followerCount = await prisma.follow.count({
-      where: { followerId: id },
-    });
-    const followingCount = await prisma.follow.count({
-      where: { followingId: id },
-    });
-
-    if (!data) {
-      return c.json({ message: "user not found" }, 404);
-    }
-
-    const formattedData = {
-      ...data,
-      followerCount: followerCount,
-      followingCount: followingCount,
-    };
-
-    return c.json(formattedData);
-  } catch (error) {
-    console.error("Error fetching user:", error);
-    return c.text(error as string);
-  }
-});
-
-// ユーザー情報を更新するエンドポイント
-app.patch("/:id", zValidator("json", userScheme), async (c) => {
-  const id = c.req.param("id");
-  const body = c.req.valid("json");
-
-  try {
-    const user = await prisma.user.update({
-      where: { id: id },
-      data: body,
-    });
-    return c.json({ message: "User updated", user: user });
-  } catch (error) {
-    if (error instanceof Error) {
-      return c.json({ error: error.message }, 500);
-    }
-    return c.json({ error: "Unknown error" }, 500);
-  }
-});
-
-// フォローするエンドポイント
-app.post("/:id/follow/:followerId", async (c) => {
-  const id = c.req.param("id");
-  const followerId = c.req.param("followerId");
-  const session = await getServerSession(authOptions);
-  if (!session) {
-    return c.json({ error: "ログインしていないユーザーです" }, 401);
-  }
-
-  try {
-    const follow = await recoverFromNotFound(
-      prisma.follow.create({
-        data: {
-          followerId: followerId,
-          followingId: id,
-        },
-      }),
-    );
-
-    if (!follow) {
-      return c.json({ error: "既にフォローしています" }, 500);
-    }
-
-    return c.json({ message: "フォロー完了", follow: follow });
-  } catch (error) {
-    if (!error) {
-      console.error("ユーザーのフォロー処理に失敗しました:", error);
-    } else {
-      console.error("ユーザーのフォロー処理に失敗しました:");
-    }
-    return c.json({ error: "ユーザーフォロー処理に失敗しました" }, 500);
-  }
-});
-
-// フォロー解除するエンドポイント
-app.delete("/:id/follow/:followerId", async (c) => {
-  const id = c.req.param("id");
-  const followerId = c.req.param("followerId");
-  const session = await getServerSession(authOptions);
-  if (!session) {
-    return c.json({ error: "ログインしていないユーザーです" }, 401);
-  }
-
-  try {
-    const follow = await recoverFromNotFound(
-      prisma.follow.delete({
+app
+  .get("/:id", async (c) => {
+    const id = c.req.param("id");
+    try {
+      const data = await prisma.user.findUnique({
         where: {
-          followerId_followingId: {
-            followingId: id,
-            followerId: followerId,
+          id: id,
+        },
+        include: {
+          goals: {
+            select: {
+              id: true,
+              isPublic: true,
+              text: true,
+            },
+          },
+          UserInterest: {
+            select: {
+              interest: true,
+            },
           },
         },
-      }),
-    );
-    if (!follow) {
-      return c.json({ error: "フォローしていません" }, 500);
+      });
+
+      const followerCount = await prisma.follow.count({
+        where: { followerId: id },
+      });
+      const followingCount = await prisma.follow.count({
+        where: { followingId: id },
+      });
+
+      if (!data) {
+        return c.json({ message: "user not found" }, 404);
+      }
+
+      const formattedData = {
+        ...data,
+        followerCount: followerCount,
+        followingCount: followingCount,
+      };
+
+      return c.json(formattedData);
+    } catch (error) {
+      console.error("Error fetching user:", error);
+      return c.text(error as string);
+    }
+  })
+  // ユーザー情報を更新するエンドポイント
+  .patch("/:id", zValidator("json", userScheme), async (c) => {
+    const id = c.req.param("id");
+    const body = c.req.valid("json");
+
+    try {
+      const user = await prisma.user.update({
+        where: { id: id },
+        data: body,
+      });
+      return c.json({ message: "User updated", user: user });
+    } catch (error) {
+      if (error instanceof Error) {
+        return c.json({ error: error.message }, 500);
+      }
+      return c.json({ error: "Unknown error" }, 500);
+    }
+  })
+  // フォローするエンドポイント
+  .post("/:id/follow/:followerId", async (c) => {
+    const id = c.req.param("id");
+    const followerId = c.req.param("followerId");
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return c.json({ error: "ログインしていないユーザーです" }, 401);
     }
 
-    return c.json({ message: "フォロー解除完了", follow: follow });
-  } catch (error) {
-    if (!error) {
-      console.error("ユーザーのフォロー解除処理に失敗しました:", error);
-    } else {
-      console.error("ユーザーのフォロー解除処理に失敗しました:");
+    try {
+      const follow = await recoverFromNotFound(
+        prisma.follow.create({
+          data: {
+            followerId: followerId,
+            followingId: id,
+          },
+        }),
+      );
+
+      if (!follow) {
+        return c.json({ error: "既にフォローしています" }, 500);
+      }
+
+      return c.json({ message: "フォロー完了", follow: follow });
+    } catch (error) {
+      if (!error) {
+        console.error("ユーザーのフォロー処理に失敗しました:", error);
+      } else {
+        console.error("ユーザーのフォロー処理に失敗しました:");
+      }
+      return c.json({ error: "ユーザーフォロー処理に失敗しました" }, 500);
     }
-    return c.json({ error: "ユーザーフォロー解除処理に失敗しました" }, 500);
-  }
-});
+  })
+  // フォロー解除するエンドポイント
+  .delete("/:id/follow/:followerId", async (c) => {
+    const id = c.req.param("id");
+    const followerId = c.req.param("followerId");
+    const session = await getServerSession(authOptions);
+    if (!session) {
+      return c.json({ error: "ログインしていないユーザーです" }, 401);
+    }
+
+    try {
+      const follow = await recoverFromNotFound(
+        prisma.follow.delete({
+          where: {
+            followerId_followingId: {
+              followingId: id,
+              followerId: followerId,
+            },
+          },
+        }),
+      );
+      if (!follow) {
+        return c.json({ error: "フォローしていません" }, 500);
+      }
+
+      return c.json({ message: "フォロー解除完了", follow: follow });
+    } catch (error) {
+      if (!error) {
+        console.error("ユーザーのフォロー解除処理に失敗しました:", error);
+      } else {
+        console.error("ユーザーのフォロー解除処理に失敗しました:");
+      }
+      return c.json({ error: "ユーザーフォロー解除処理に失敗しました" }, 500);
+    }
+  });
 export default app;

--- a/src/app/api/[[...route]]/users/index.ts
+++ b/src/app/api/[[...route]]/users/index.ts
@@ -94,15 +94,21 @@ app.post("/:id/follow/:followerId", async (c) => {
   }
 
   try {
-    const follow = await prisma.follow.upsert({
-      where: {
-        followerId_followingId: {
-          followingId: id,
-          followerId: followerId,
-        },
-      },
-      update: {},
-      create: {
+    // const follow = await prisma.follow.upsert({
+    //   where: {
+    //     followerId_followingId: {
+    //       followingId: id,
+    //       followerId: followerId,
+    //     },
+    //   },
+    //   update: {},
+    //   create: {
+    //     followerId: followerId,
+    //     followingId: id,
+    //   },
+    // });
+    const follow = await prisma.follow.create({
+      data: {
         followerId: followerId,
         followingId: id,
       },
@@ -110,6 +116,15 @@ app.post("/:id/follow/:followerId", async (c) => {
 
     return c.json({ message: "フォロー完了", follow: follow });
   } catch (error) {
+    const isFollowing = await prisma.follow.findFirst({
+      where: {
+        followerId: followerId,
+        followingId: id,
+      },
+    });
+    if (isFollowing) {
+      return c.json({ error: "既にフォローされています" }, 500);
+    }
     if (!error) {
       console.error("ユーザーのフォロー処理に失敗しました:", error);
     } else {


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
[delete] /users/:id/follow/:followerId の実装

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #27 

## 変更内容
<!-- 変更内容を具体的に記載してください -->
### `src/app/api/[[...route]]/users/index.ts`
- [ ] prismaのdelete機能でfollowテーブルから該当の要素を削除するフォロー解除機能を実装
- [ ] [post] /users/:id/follow/:followerId の実装では，upsertを使用していたが，deleteで既にフォロー解除済みのハンドリングをしていたので，createに実装を変更してフォロー済みのハンドリングを行う実装に変更

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->

### 変更前

### 変更後

## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [x] ローカル環境で動作確認済み
- [ ] 必要なテストを追加/更新済み
- [ ] テストが全て成功することを確認済み
- [x] Lintエラーがないことを確認済み

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->
* deleteもupsertのような実装ができるかどうか
* 

## その他
<!-- その他、補足事項があれば記載してください -->
* supabaseに接続できていてかつ，フォロー解除された状態で発生する何かしらのエラーが存在するなら，そのエラーを見つけられない状態になるかもしれないので，ハンドリングをしない実装にしようかなと思う．
  * そのエラーが発生した時にも「既にフォローが解除された状態です」になる気がしている