### PR TITLE
#113 [Bug🐛] ポモドーロタイマーで作業時間を変更した際に、砂時計の時間も連動させる 

### DIFF
--- a/src/app/_features/Pomodoro/PomodoroPage/PomodoroPageContainer.tsx
+++ b/src/app/_features/Pomodoro/PomodoroPage/PomodoroPageContainer.tsx
@@ -1,15 +1,25 @@
 "use client";
 
 import { PomodoroPageView } from "@/app/_features/Pomodoro/PomodoroPage/PomodoroPageView";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function PomodoroPageContainer() {
   const [isRunning, setIsRunning] = useState(false);
-  const [timeLeft, setTimeLeft] = useState(25 * 60);
   const [workDuration, setWorkDuration] = useState(25);
+  const [timeLeft, setTimeLeft] = useState(workDuration * 60);
   const [breakDuration, setBreakDuration] = useState(5);
   const [isBreak, setIsBreak] = useState(false);
   const [sound, setSound] = useState(true);
+
+  useEffect(() => {
+    if (isRunning) return;
+
+    if (!isBreak) {
+      setTimeLeft(workDuration * 60);
+    } else {
+      setTimeLeft(breakDuration * 60);
+    }
+  }, [workDuration, breakDuration, isBreak, isRunning]);
 
   const handleStart = () => {
     setIsRunning(true);
@@ -21,8 +31,21 @@ export default function PomodoroPageContainer() {
 
   const handleReset = () => {
     setIsRunning(false);
-    setTimeLeft(workDuration * 60);
-    setIsBreak(false);
+    setTimeLeft(isBreak ? breakDuration * 60 : workDuration * 60);
+  };
+
+  const handleWorkDurationChange = (value: number) => {
+    setWorkDuration(value);
+    if (!isRunning && !isBreak) {
+      setTimeLeft(value * 60);
+    }
+  };
+
+  const handleBreakDurationChange = (value: number) => {
+    setBreakDuration(value);
+    if (!isRunning && isBreak) {
+      setTimeLeft(value * 60);
+    }
   };
 
   const handleComplete = () => {
@@ -42,9 +65,9 @@ export default function PomodoroPageContainer() {
       isBreak={isBreak}
       onComplete={handleComplete}
       workDuration={workDuration}
-      setWorkDuration={setWorkDuration}
+      setWorkDuration={handleWorkDurationChange}
       breakDuration={breakDuration}
-      setBreakDuration={setBreakDuration}
+      setBreakDuration={handleBreakDurationChange}
       sound={sound}
       setSound={setSound}
       onStart={handleStart}

--- a/src/app/_features/Pomodoro/PomodoroPage/PomodoroPageContainer.tsx
+++ b/src/app/_features/Pomodoro/PomodoroPage/PomodoroPageContainer.tsx
@@ -22,6 +22,10 @@ export default function PomodoroPageContainer() {
   }, [workDuration, breakDuration, isBreak, isRunning]);
 
   const handleStart = () => {
+    if (sound) {
+      const audio = new Audio("/sound/pomodoro.mp3");
+      audio.play();
+    }
     setIsRunning(true);
   };
 

--- a/src/app/_features/Pomodoro/PomodoroPage/PomodoroPageContainer.tsx
+++ b/src/app/_features/Pomodoro/PomodoroPage/PomodoroPageContainer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PomodoroPageView } from "@/app/_features/Pomodoro/PomodoroPage/PomodoroPageView";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export default function PomodoroPageContainer() {
   const [isRunning, setIsRunning] = useState(false);
@@ -10,16 +10,6 @@ export default function PomodoroPageContainer() {
   const [breakDuration, setBreakDuration] = useState(5);
   const [isBreak, setIsBreak] = useState(false);
   const [sound, setSound] = useState(true);
-
-  useEffect(() => {
-    if (isRunning) return;
-
-    if (!isBreak) {
-      setTimeLeft(workDuration * 60);
-    } else {
-      setTimeLeft(breakDuration * 60);
-    }
-  }, [workDuration, breakDuration, isBreak, isRunning]);
 
   const handleStart = () => {
     if (sound) {


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
状態管理を行うことで、ポモドーロタイマーとシークバーを連動させる

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #113 

## 変更内容
<!-- 変更内容を具体的に記載してください -->
- [x] ポモドーロ時間の状態管理周り

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->

### 変更前

### 変更後

## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [x] ローカル環境で動作確認済み
- [ ] 必要なテストを追加/更新済み
- [ ] テストが全て成功することを確認済み
- [ ] Lintエラーがないことを確認済み

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->

## その他
<!-- その他、補足事項があれば記載してください -->