### PR TITLE
#29 TL用API実装

### DIFF
--- a/src/app/api/[[...route]]/reports/reaction.ts
+++ b/src/app/api/[[...route]]/reports/reaction.ts
@@ -7,87 +7,85 @@ import { getServerSession } from "next-auth";
 import { z } from "zod";
 import { CheckReportAccessPermission } from "./utils";
 
-const app = new Hono();
-
-app.post(
-  "/:id/reaction/:typeId",
-  zValidator(
-    "param",
-    z.object({
-      id: z.string().cuid(),
-      typeId: z.string().cuid(),
-    }),
-  ),
-  async (c) => {
-    const session = await getServerSession(authOptions);
-    if (!session) {
-      return c.json({ error: "ログインしていないユーザーです" }, 401);
-    }
-
-    const { id: reportId, typeId } = c.req.param();
-
-    try {
-      const result = await CheckReportAccessPermission(reportId, session.user.id, c);
-
-      if (result._status !== 200) {
-        return result;
+const app = new Hono()
+  .post(
+    "/:id/reaction/:typeId",
+    zValidator(
+      "param",
+      z.object({
+        id: z.string().cuid(),
+        typeId: z.string().cuid(),
+      }),
+    ),
+    async (c) => {
+      const session = await getServerSession(authOptions);
+      if (!session) {
+        return c.json({ error: "ログインしていないユーザーです" }, 401);
       }
 
-      const reaction = await prisma.reaction.create({
-        data: {
-          typeId: typeId,
-          userId: session.user.id,
-          reportId,
-        },
-      });
+      const { id: reportId, typeId } = c.req.param();
 
-      return c.json({ reaction }, 201);
-    } catch (error) {
-      console.error(error);
-      return c.json({ error: "リアクションの付与に失敗しました" }, 500);
-    }
-  },
-);
+      try {
+        const result = await CheckReportAccessPermission(reportId, session.user.id, c);
 
-app.delete(
-  "/:id/reaction/:typeId",
-  zValidator(
-    "param",
-    z.object({
-      id: z.string().cuid(),
-      typeId: z.string().cuid(),
-    }),
-  ),
-  async (c) => {
-    const session = await getServerSession(authOptions);
-    if (!session) {
-      return c.json({ error: "ログインしていないユーザーです" }, 401);
-    }
+        if (result._status !== 200) {
+          return result;
+        }
 
-    const { id: reportId, typeId } = c.req.param();
-
-    try {
-      const reaction = await recoverFromNotFound(
-        prisma.reaction.delete({
-          where: {
-            typeId_userId_reportId: {
-              typeId,
-              reportId,
-              userId: session.user.id,
-            },
+        const reaction = await prisma.reaction.create({
+          data: {
+            typeId: typeId,
+            userId: session.user.id,
+            reportId,
           },
-        }),
-      );
+        });
 
-      if (!reaction) {
-        return c.json({ error: "対象のリアクションが見つかりません" }, 404);
+        return c.json({ reaction }, 201);
+      } catch (error) {
+        console.error(error);
+        return c.json({ error: "リアクションの付与に失敗しました" }, 500);
       }
-      return c.json({ message: "リアクションを削除しました" }, 200);
-    } catch (error) {
-      console.error(error);
-      return c.json({ error: "リアクションの削除に失敗しました" }, 500);
-    }
-  },
-);
+    },
+  )
+  .delete(
+    "/:id/reaction/:typeId",
+    zValidator(
+      "param",
+      z.object({
+        id: z.string().cuid(),
+        typeId: z.string().cuid(),
+      }),
+    ),
+    async (c) => {
+      const session = await getServerSession(authOptions);
+      if (!session) {
+        return c.json({ error: "ログインしていないユーザーです" }, 401);
+      }
+
+      const { id: reportId, typeId } = c.req.param();
+
+      try {
+        const reaction = await recoverFromNotFound(
+          prisma.reaction.delete({
+            where: {
+              typeId_userId_reportId: {
+                typeId,
+                reportId,
+                userId: session.user.id,
+              },
+            },
+          }),
+        );
+
+        if (!reaction) {
+          return c.json({ error: "対象のリアクションが見つかりません" }, 404);
+        }
+        return c.json({ message: "リアクションを削除しました" }, 200);
+      } catch (error) {
+        console.error(error);
+        return c.json({ error: "リアクションの削除に失敗しました" }, 500);
+      }
+    },
+  );
 
 export default app;


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
ログインしていない場合、プライベートでないユーザーのPUBLICな日報を取得
ログインしている場合、
- プライベートでないユーザーのPUBLICな日報
- プライベートでないフォローしているユーザーのFOLLOWERSな投稿
- 自分のFOLLOWERS || PUBLICな投稿
  - Privateは下書きなので、表示しない

共通
createdAtで降順
30件まで

更新したときとかの挙動とか考えてないです
まぁ一旦ね？


## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #29 

## 確認してほしいこと
フォローしている人のだけ表示するTLも欲しいかな？
上の実装で要件を満たせるか
他に結合したいテーブルはあるか

## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [x] ローカル環境で動作確認済み
- [ ] 必要なテストを追加/更新済み
- [ ] テストが全て成功することを確認済み
- [x] Lintエラーがないことを確認済み

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->

## その他
<!-- その他、補足事項があれば記載してください -->