### PR TITLE
#228 [Feat✨] プロフィールでユーザーの日報だけ表示 

### DIFF
--- a/src/app/_features/Profile/ProfilePage/ProfilePageView.tsx
+++ b/src/app/_features/Profile/ProfilePage/ProfilePageView.tsx
@@ -185,7 +185,7 @@ export default function ProfilePageView({
                   }}
                 >
                   {/* isNested=trueを指定して、プロフィールページ内に埋め込まれていることを伝える */}
-                  <Timeline isNested={true} />
+                  <Timeline isNested={true} userId={user.id} />
                 </div>
               </div>
             </Card>

--- a/src/app/_features/Profile/ProfileRecommendedUsers/ProfileRecommendedUsersCard/ProfileRecommendedUserCard.tsx
+++ b/src/app/_features/Profile/ProfileRecommendedUsers/ProfileRecommendedUsersCard/ProfileRecommendedUserCard.tsx
@@ -43,10 +43,16 @@ export function ProfileRecommendedUserCard({
   };
 
   return (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: <explanation>
     <div
-      className={`relative w-48 bg-primary-foreground rounded-lg shadow-md border overflow-hidden flex flex-col justify-between flex-shrink-0 hover:shadow-lg transition-shadow ${clickable && "cursor-pointer"}`}
-      onClick={() => clickable && navigateToProfile}
+      className={`relative w-48 bg-primary-foreground rounded-lg shadow-md border overflow-hidden flex flex-col justify-between flex-shrink-0 hover:shadow-lg transition-shadow ${clickable ? "cursor-pointer" : ""}`}
+      onClick={() => clickable && navigateToProfile()}
+      role={clickable ? "button" : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (clickable && (e.key === "Enter" || e.key === " ")) {
+          navigateToProfile();
+        }
+      }}
     >
       <div className="w-full">
         {/* プロフィール画像 */}

--- a/src/app/_features/Timeline/Timeline.tsx
+++ b/src/app/_features/Timeline/Timeline.tsx
@@ -6,11 +6,12 @@ import { useEffect, useRef, useState } from "react";
 
 export type ViewMode = "category" | "following" | "mine";
 
-export function Timeline({ isNested = false }) {
+export function Timeline({ isNested = false, userId }: { isNested?: boolean; userId?: string }) {
   const [viewMode, setViewMode] = useState<ViewMode>("category");
   // ローディング状態を個別に管理
   const [isChangingMode, setIsChangingMode] = useState(false);
-  const { reports, isLoading, hasMore, refetchReports } = useReports(viewMode);
+  // userId がある場合はそのユーザーの投稿を取得
+  const { reports, isLoading, hasMore, refetchReports } = useReports(viewMode, userId);
 
   // 監視対象の要素
   const loaderRef = useRef<HTMLDivElement | null>(null);
@@ -61,6 +62,7 @@ export function Timeline({ isNested = false }) {
       onChangeViewMode={handleChangeViewMode}
       onReportDeleted={refetchReports}
       isNested={isNested}
+      userId={userId}
     />
   );
 }

--- a/src/app/_features/Timeline/TimelineView.tsx
+++ b/src/app/_features/Timeline/TimelineView.tsx
@@ -19,6 +19,7 @@ type TimelineViewProps = {
   onReportDeleted?: () => Promise<void>;
   style?: CSSProperties;
   isNested?: boolean;
+  userId?: string;
 };
 
 export function TimelineView({
@@ -31,9 +32,13 @@ export function TimelineView({
   onReportDeleted,
   style,
   isNested,
+  userId,
 }: TimelineViewProps) {
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
+
+  // ユーザーIDが指定されている場合は、モード切り替えボタンを表示しない
+  const showModeButtons = !userId;
 
   // シンプルな個別アニメーション設定
   const fadeIn = {
@@ -44,34 +49,37 @@ export function TimelineView({
 
   return (
     <div className="w-full max-w-2xl mx-auto">
-      <motion.div
-        className="flex justify-between mb-4 p-2 bg-card rounded-md"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.3 }}
-      >
-        <Button
-          variant={viewMode === "category" ? "default" : "outline"}
-          onClick={() => onChangeViewMode("category")}
-          className="flex-1 mx-1 text-primary-foreground"
+      {showModeButtons && (
+        <motion.div
+          className="flex justify-between mb-4 p-2 bg-card rounded-md"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
         >
-          カテゴリー
-        </Button>
-        <Button
-          variant={viewMode === "following" ? "default" : "outline"}
-          onClick={() => onChangeViewMode("following")}
-          className="flex-1 mx-1 text-primary-foreground"
-        >
-          フォロー中
-        </Button>
-        <Button
-          variant={viewMode === "mine" ? "default" : "outline"}
-          onClick={() => onChangeViewMode("mine")}
-          className="flex-1 mx-1 text-primary-foreground"
-        >
-          自分の投稿
-        </Button>
-      </motion.div>
+          <Button
+            variant={viewMode === "category" ? "default" : "outline"}
+            onClick={() => onChangeViewMode("category")}
+            className="flex-1 mx-1 text-primary-foreground"
+          >
+            カテゴリー
+          </Button>
+          <Button
+            variant={viewMode === "following" ? "default" : "outline"}
+            onClick={() => onChangeViewMode("following")}
+            className="flex-1 mx-1 text-primary-foreground"
+          >
+            フォロー中
+          </Button>
+          <Button
+            variant={viewMode === "mine" ? "default" : "outline"}
+            onClick={() => onChangeViewMode("mine")}
+            className="flex-1 mx-1 text-primary-foreground"
+          >
+            自分の投稿
+          </Button>
+        </motion.div>
+      )}
+
       <div
         className="overflow-y-auto border rounded-md p-2 space-y-4 custom-scrollbar"
         style={{
@@ -79,6 +87,7 @@ export function TimelineView({
           height: "100%",
         }}
       >
+        {userId && <div className="text-lg font-semibold p-2 border-b">投稿一覧</div>}
         {/* ローディング中は中央に表示 */}
         {isLoading ? (
           <motion.div className="flex items-center justify-center h-full" {...fadeIn}>

--- a/src/app/hooks/useReprots.ts
+++ b/src/app/hooks/useReprots.ts
@@ -20,7 +20,7 @@ const VIEW_MODE_TO_API_TYPE: Record<ViewMode, "sameCategory" | "following" | "ow
   mine: "own",
 };
 
-export function useReports(viewMode: ViewMode = "category") {
+export function useReports(viewMode: ViewMode = "category", userId?: string) {
   const { data: session } = useSession();
   const currentUserId = session?.user?.id;
 
@@ -35,8 +35,10 @@ export function useReports(viewMode: ViewMode = "category") {
       // ViewMode に応じた type パラメータを設定
       const type = VIEW_MODE_TO_API_TYPE[viewMode];
 
+      const queryParams = userId ? { userId } : { type };
+
       const response = await client.api.reports.$get({
-        query: { type },
+        query: queryParams,
       });
 
       if (!response.ok) {
@@ -50,8 +52,6 @@ export function useReports(viewMode: ViewMode = "category") {
       }
 
       const data = await response.json();
-      // biome-ignore lint/suspicious/noConsoleLog: <explanation>
-      console.log(`Received ${data.reports?.length || 0} reports`);
 
       setReports(
         data.reports.map((r) => ({
@@ -96,7 +96,7 @@ export function useReports(viewMode: ViewMode = "category") {
     } finally {
       setIsLoading(false);
     }
-  }, [currentUserId, viewMode]);
+  }, [currentUserId, viewMode, userId]);
 
   useEffect(() => {
     refetchReports();


### PR DESCRIPTION
# 概要
<!-- 変更内容の概要を簡潔に記述してください -->
プロフィールページにて任意のユーザーの日報だけ表示するようにした。

## 関連Issue
<!-- 関連するIssueがあれば記載してください -->
- Close #228

## 変更内容
<!-- 変更内容を具体的に記載してください -->
- [x] TimelineでuserIdを受け取るようにする
- [x] userIdの有無でカテゴリの表示切り替え

## スクリーンショット
<!-- UIの変更がある場合は、変更前後のスクリーンショットを添付してください -->

### 変更前

### 変更後

## 動作確認項目
<!-- 確認した項目にチェックを入れてください -->
- [ ] ローカル環境で動作確認済み
- [ ] 必要なテストを追加/更新済み
- [ ] テストが全て成功することを確認済み
- [ ] Lintエラーがないことを確認済み

## レビュー時の注意点
<!-- レビュアーに特に見て欲しい点があれば記載してください -->

## その他
<!-- その他、補足事項があれば記載してください -->